### PR TITLE
Fix Segmentation fault in Cheats menu

### DIFF
--- a/gambatte_sdl/menu.cpp
+++ b/gambatte_sdl/menu.cpp
@@ -103,13 +103,11 @@ void show_fps(SDL_Surface *surface, int fps) {
 }
 
 std::string numtohextext(int num){
-    std::locale loc;
     char buffer[4];
     std::string result;
     sprintf(buffer, "%x", num);
 
-    result = std::string(buffer);
-    result = std::toupper(buffer[0],loc);
+    result = std::toupper(buffer[0]);
 
     return result;
 }


### PR DESCRIPTION
It looks like uninitialized loc for toupper() causes Segmentation fault.
Leaving the Cheats menu no longer crashes after the modification, not tested for actual gamegenie/gameshark functionality.